### PR TITLE
Enable Gemini LLM analysis

### DIFF
--- a/app/generate/gemini/__init__.py
+++ b/app/generate/gemini/__init__.py
@@ -1,8 +1,12 @@
-"""
-Gemini API integration module
-"""
+"""Gemini API integration module"""
 
 from .api_key_manager import APIKeyManager
-from .reset_api_key import reset_api_key
+from .reset_api_key import reset_api_key, retry_with_backoff
+from .gemini import generate_gemini_response
 
-__all__ = ['APIKeyManager', 'reset_api_key']
+__all__ = [
+    'APIKeyManager',
+    'reset_api_key',
+    'retry_with_backoff',
+    'generate_gemini_response',
+]

--- a/app/generate/gemini/gemini.py
+++ b/app/generate/gemini/gemini.py
@@ -1,0 +1,33 @@
+"""Gemini API interface for generating MBTI analysis"""
+
+from typing import Optional
+import os
+import google.generativeai as genai
+
+from .api_key_manager import APIKeyManager
+from .reset_api_key import retry_with_backoff
+
+
+def _configure_genai(api_key: str):
+    """Configure the generative AI client."""
+    genai.configure(api_key=api_key)
+
+
+def generate_gemini_response(prompt: str, model: Optional[str] = None, temperature: float = 0.7, max_tokens: int = 1024) -> str:
+    """Generate text from Gemini model using the given prompt."""
+    key_manager = APIKeyManager()
+    api_key = key_manager.get_current_key()
+    _configure_genai(api_key)
+
+    model_name = model or os.getenv("GEMINI_MODEL", "gemini-pro")
+
+    def _call():
+        gen_model = genai.GenerativeModel(model_name)
+        response = gen_model.generate_content(
+            prompt,
+            generation_config={"temperature": temperature, "max_output_tokens": max_tokens},
+        )
+        return response.text
+
+    # Use retry_with_backoff to handle errors and rotate keys if needed
+    return retry_with_backoff(key_manager, _call)

--- a/src/deduplication.py
+++ b/src/deduplication.py
@@ -48,8 +48,11 @@ class ResponseDeduplicator:
         # Keep only one response per exact content group
         unique_responses = []
         for group in content_groups.values():
-            # Keep the response with highest score if available
-            best_response = max(group, key=lambda x: x.get('score', 0))
+            # Keep the response with highest similarity/score if available
+            best_response = max(
+                group,
+                key=lambda x: x.get('hybrid_score', x.get('semantic_similarity', 0)),
+            )
             unique_responses.append(best_response)
         
         return unique_responses


### PR DESCRIPTION
## Summary
- adjust deduplicator to choose best result using available hybrid score
- expose Gemini integration helpers
- implement Gemini API client for MBTI prompts
- allow MBTI pipeline to call Gemini for analysis and respect weight settings

## Testing
- `pytest -q`
- `python -m py_compile src/*.py app/generate/gemini/*.py app.py`

------
https://chatgpt.com/codex/tasks/task_b_6857b607f80883338c2b06cf1cefe680